### PR TITLE
[Feat]: Add Dyanamic date functionality to copyright footer section 

### DIFF
--- a/index.html
+++ b/index.html
@@ -612,8 +612,13 @@
     </footer>
         
         <div class="footer-copyright">
-            <div id="copyright">&copy; 2024 TrendTrove. All Rights Reserved.</div>
+            <div id="copyright">&copy; <span id="year"></span> TrendTrove. All Rights Reserved.</div>
         </div>
+        
+        <script>
+            const currentYear = new Date().getFullYear();
+            document.getElementById('year').textContent = currentYear;
+        </script>
         
         <div class="modal-box" id="modalbox" style="display: none;">
             <div class="modal" id="modal">


### PR DESCRIPTION
Hi @Tejashri-Taral 

- fixes #476

I have added dynamic year to the copyright section
![image](https://github.com/user-attachments/assets/b7c142b4-193b-4416-92bd-c910467159b1)


Now, every time the page is loaded, the JavaScript will ensure that the copyright year is updated automatically based on the current date.






