### PR TITLE
#623 solved: added kids and accessories sections under products tab

### DIFF
--- a/about.html
+++ b/about.html
@@ -422,6 +422,8 @@
                         <li><a href="mens.html" class="priye">Men</a>
                         </li>
                         <li><a href="womens.html">Women</a></li>
+                        <li><a href="child.html">Kid Section</a></li>
+                        <li><a href="accessories.html">Accessories</a></li>
                     </ul>
                 </li>
                 <li class="tab" style="margin-left: 15px;">

--- a/contact.html
+++ b/contact.html
@@ -56,6 +56,8 @@
                             <li><a href="mens.html" class="priye">Men</a>
                             </li>
                             <li><a href="womens.html">Women</a></li>
+                            <li><a href="child.html">Kid Section</a></li>
+                            <li><a href="accessories.html">Accessories</a></li>
                         </ul>
                     </li>
                     <li class="tab" style="margin-left: 15px;">

--- a/features.html
+++ b/features.html
@@ -70,6 +70,8 @@
                             <li><a href="mens.html" class="priye">Men</a>
                             </li>
                             <li><a href="womens.html">Women</a></li>
+                            <li><a href="child.html">Kid Section</a></li>
+                            <li><a href="accessories.html">Accessories</a></li>
                         </ul>
                     </li>
                     <li class="tab" style="margin-left: 15px;">

--- a/privacy.html
+++ b/privacy.html
@@ -97,6 +97,8 @@
                             <li><a href="mens.html" class="priye">Mens</a>
                             </li>
                             <li><a href="womens.html">Womens</a></li>
+                            <li><a href="child.html">Kid Section</a></li>
+                            <li><a href="accessories.html">Accessories</a></li>
                         </ul>
                     </li>
                     <li class="tab" style="margin-left: 15px;">

--- a/return-policy.html
+++ b/return-policy.html
@@ -40,6 +40,8 @@
                             <li><a href="mens.html" class="priye">Mens</a>
                             </li>
                             <li><a href="womens.html">Womens</a></li>
+                            <li><a href="child.html">Kid Section</a></li>
+                            <li><a href="accessories.html">Accessories</a></li>
                         </ul>
                     </li>
                     <li class="tab" style="margin-left: 15px;">

--- a/shopclothing.html
+++ b/shopclothing.html
@@ -305,6 +305,8 @@
                             <li><a href="mens.html" class="priye">Mens</a>
                             </li>
                             <li><a href="womens.html">Womens</a></li>
+                            <li><a href="child.html">Kid Section</a></li>
+                            <li><a href="accessories.html">Accessories</a></li>
                         </ul>
                     </li>
                     <li class="tab" style="margin-left: 15px;">

--- a/sneaker.html
+++ b/sneaker.html
@@ -304,6 +304,8 @@
                             <li><a href="mens.html" class="priye">Mens</a>
                             </li>
                             <li><a href="womens.html">Womens</a></li>
+                            <li><a href="child.html">Kid Section</a></li>
+                            <li><a href="accessories.html">Accessories</a></li>
                         </ul>
                     </li>
                     <li class="tab" style="margin-left: 15px;">

--- a/terms-conditions.html
+++ b/terms-conditions.html
@@ -39,6 +39,8 @@
                             <li><a href="mens.html" class="priye">Mens</a>
                             </li>
                             <li><a href="womens.html">Womens</a></li>
+                            <li><a href="child.html">Kid Section</a></li>
+                            <li><a href="accessories.html">Accessories</a></li>
                         </ul>
                     </li>
                     <li class="tab" style="margin-left: 15px;">


### PR DESCRIPTION
i have added the kids and accessories section under products tab on all the pages it was missing on 
closes #623 
here is the result:


https://github.com/user-attachments/assets/ffe00cd4-e3fb-4378-9ab6-f6c74eb8c1c6

please do add hacktoberfest-accepted and gssoc label !!! thanks