### PR TITLE
fixes #791 [overlapping visitor counts and social media links]

### DIFF
--- a/style.css
+++ b/style.css
@@ -849,7 +849,7 @@ html {
   position: absolute;
   background-color: #000000;
   color: rgb(255, 255, 255);
-  top: 3618px;
+  top: 3650px;
   padding: 10px 20px;
   border-radius: 19px;
   display: inline-flex;


### PR DESCRIPTION
fixed teh issue with visitor count button overlapping with the social media links in the footer section of the homepage.
before-
![image](https://github.com/user-attachments/assets/9d8f48f3-c747-4d84-9468-92cd66f07bbd)


AFTER-
![image](https://github.com/user-attachments/assets/0790f7e4-f2ee-4ab3-8ba9-814ac629aae3)
closes #791 