### PR TITLE
Add scale-up hover effect for images in the about section

### DIFF
--- a/about.html
+++ b/about.html
@@ -150,6 +150,14 @@
         padding: 0 40px; /* Increased padding for a more spacious layout */
       }
 
+      .about-images img {
+  transition: transform 0.3s ease-in-out; /* Smooth transition */
+}
+
+.about-images:hover img {
+  transform: scale(1.1); /* Scale the image up on hover */
+}
+
       /* Footer Section */
       /* .footer {
         background-color: #bec1c55c;


### PR DESCRIPTION
Added a smooth scale-up effect on hover for images in the about section. The images now scale by 1.1x with a smooth transition when hovering over the .about-images container.

fixes: #816 


Here's the video demonstrating the changes:

https://github.com/user-attachments/assets/126b9fd5-e34b-495c-9bb7-277810f39609

Feel free to merge it! 